### PR TITLE
Automatically merge dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,9 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:base"],
 
+  // Automatically merge pull requests that pass the required status checks
+  automerge: true,
+
   // Disable creating a GitHub issue that lists all available dependency updates
   dependencyDashboard: false,
 

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -35,7 +35,7 @@ jobs:
           done
 
   style:
-    name: Check style
+    name: Check JSON style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -35,7 +35,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint Markdown files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -51,7 +51,7 @@ jobs:
           files: "**.md"
 
   style:
-    name: Check style
+    name: Check Markdown style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint Rust code
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -68,7 +68,7 @@ jobs:
         run: just lint
 
   style:
-    name: Check style
+    name: Check Rust style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -36,7 +36,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint YAML files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -50,7 +50,7 @@ jobs:
         uses: actionshub/yamllint@v1.8.2
 
   style:
-    name: Check style
+    name: Check YAML style
     runs-on: ubuntu-latest
 
     needs: detect-changes


### PR DESCRIPTION
Pull requests that update dependencies and pass the required status checks can now be merged automatically by Renovate. The only necessary change for this feature is that required status checks have unique names, otherwise Renovate will merge the pull request after the first checks are skipped (and thus "succesful").