### PR TITLE
Update Rust version automatically

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,18 @@
       fileMatch: ["^.github/workflows/rust.yml$"],
       matchStrings: ["prefix-key: [\\w]+-(?<currentValue>.*?)\\n"],
       depNameTemplate: "rust",
-      datasourceTemplate: "docker",
+      lookupNameTemplate: "rust-lang/rust",
+      datasourceTemplate: "github-tags",
+    },
+    {
+      customType: "regex",
+      fileMatch: ["(^|/)rust-toolchain\\.toml?$"],
+      matchStrings: [
+        'channel\\s*=\\s*"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)"',
+      ],
+      depNameTemplate: "rust",
+      lookupNameTemplate: "rust-lang/rust",
+      datasourceTemplate: "github-tags",
     },
   ],
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.79.0"


### PR DESCRIPTION
Whenever a new version of Rust is releases, the toolchain for the project is bumped and the cache for GitHub Actions is evicted. This ensures that all developers use the same, most recent version and that the build cache doesn't grow endlessly over time, especially due to stale dependencies still being part of the cache.