### PR TITLE
Create a new test for listing release files

### DIFF
--- a/src/releases/list_files/cloudfront.rs
+++ b/src/releases/list_files/cloudfront.rs
@@ -1,0 +1,113 @@
+//! Test that CloudFront lists the files in a release
+
+use async_trait::async_trait;
+
+use crate::releases::list_files::request_index_and_expect_loading_files;
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+
+/// The name of the test
+const NAME: &str = "CloudFront";
+
+/// Test that CloudFront lists the files in a release
+///
+/// This module test that requests to the `index.html` in each release folder are rewritten to point
+/// to `list-files.html`.
+pub struct CloudFront<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> CloudFront<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for CloudFront<'a> {
+    async fn run(&self) -> TestResult {
+        request_index_and_expect_loading_files(
+            NAME,
+            self.config.cloudfront_url(),
+            self.config.release(),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_when_listing_files() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .release("2024-09-11".into())
+            .build();
+
+        let mock = server
+            .mock("GET", "/dist/2024-09-11/index.html")
+            .with_status(200)
+            .with_body(indoc! {r#"
+                Loading directory contents...
+            "#})
+            .create();
+
+        let result = CloudFront::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_otherwise() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .release("2024-09-11".into())
+            .build();
+
+        let mock = server
+            .mock("GET", "/dist/2024-09-11/index.html")
+            .with_status(404)
+            .create();
+
+        let result = CloudFront::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<CloudFront>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<CloudFront>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<CloudFront>();
+    }
+}

--- a/src/releases/list_files/config.rs
+++ b/src/releases/list_files/config.rs
@@ -1,0 +1,67 @@
+//! Configuration to test `list-files.html`
+
+use getset::Getters;
+#[cfg(test)]
+use typed_builder::TypedBuilder;
+
+use crate::environment::Environment;
+
+/// Configuration to test `list-files.html`
+///
+/// The smoke tests request the `index.html` file in a release folder and expect it to be list the
+/// files in the folder.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Getters)]
+#[cfg_attr(test, derive(TypedBuilder))]
+pub struct Config {
+    /// The URL for the CloudFront CDN
+    #[getset(get = "pub")]
+    cloudfront_url: String,
+
+    /// The URL for the Fastly CDN
+    #[getset(get = "pub")]
+    fastly_url: String,
+
+    /// The date of the release to check
+    #[getset(get = "pub")]
+    release: String,
+}
+
+impl Config {
+    /// Return the configuration for the given environment
+    pub fn for_env(env: Environment) -> Self {
+        match env {
+            Environment::Staging => Self {
+                cloudfront_url: "https://cloudfront-dev-static.rust-lang.org".into(),
+                fastly_url: "https://fastly-dev-static.rust-lang.org".into(),
+                release: "2024-09-03".into(),
+            },
+            Environment::Production => Self {
+                cloudfront_url: "https://cloudfront-static.rust-lang.org".into(),
+                fastly_url: "https://fastly-static.rust-lang.org".into(),
+                release: "2024-09-11".into(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Config>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Config>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Config>();
+    }
+}

--- a/src/releases/list_files/fastly.rs
+++ b/src/releases/list_files/fastly.rs
@@ -1,0 +1,112 @@
+//! Test that Fastly lists the files in a release
+
+use async_trait::async_trait;
+
+use crate::releases::list_files::request_index_and_expect_loading_files;
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+
+/// The name of the test
+const NAME: &str = "Fastly";
+
+/// Test that Fastly lists the files in a release
+///
+/// This module test that requests to the `index.html` in each release folder are rewritten to point
+/// to `list-files.html`.
+pub struct Fastly<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> Fastly<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for Fastly<'a> {
+    async fn run(&self) -> TestResult {
+        request_index_and_expect_loading_files(
+            NAME,
+            self.config.fastly_url(),
+            self.config.release(),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+    use indoc::indoc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_when_listing_files() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .release("2024-09-11".into())
+            .build();
+
+        let mock = server
+            .mock("GET", "/dist/2024-09-11/index.html")
+            .with_status(200)
+            .with_body(indoc! {r#"
+                Loading directory contents...
+            "#})
+            .create();
+
+        let result = Fastly::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_otherwise() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .release("2024-09-11".into())
+            .build();
+
+        let mock = server
+            .mock("GET", "/dist/2024-09-11/index.html")
+            .with_status(404)
+            .create();
+
+        let result = Fastly::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Fastly>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Fastly>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Fastly>();
+    }
+}

--- a/src/releases/list_files/mod.rs
+++ b/src/releases/list_files/mod.rs
@@ -1,0 +1,134 @@
+//! Rewrite index.html to list-files.html
+//!
+//! This module test that requests to the index.html in each release folder are rewritten to point
+//! to list-files.html.
+
+use std::fmt::{Display, Formatter};
+
+use async_trait::async_trait;
+
+use crate::environment::Environment;
+use crate::test::{Test, TestGroup, TestGroupResult, TestResult};
+
+pub use self::cloudfront::CloudFront;
+pub use self::config::Config;
+pub use self::fastly::Fastly;
+
+mod cloudfront;
+mod config;
+mod fastly;
+
+/// The name of the test group
+const NAME: &str = "list-files.html";
+
+/// Rewrite index.html to list-files.html
+///
+/// This module test that requests to the index.html in each release folder are rewritten to point
+/// to list-files.html.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct ListFiles {
+    /// Configuration for the test group
+    config: Config,
+}
+
+impl ListFiles {
+    /// Create a new instance of the test group
+    pub fn new(env: Environment) -> Self {
+        Self {
+            config: Config::for_env(env),
+        }
+    }
+}
+
+impl Display for ListFiles {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", NAME)
+    }
+}
+
+#[async_trait]
+impl TestGroup for ListFiles {
+    async fn run(&self) -> TestGroupResult {
+        let tests: Vec<Box<dyn Test>> = vec![
+            Box::new(CloudFront::new(&self.config)),
+            Box::new(Fastly::new(&self.config)),
+        ];
+
+        let mut results = Vec::new();
+        for test in tests {
+            results.push(test.run().await);
+        }
+
+        TestGroupResult::builder()
+            .name(NAME)
+            .results(results)
+            .build()
+    }
+}
+
+/// Request a releases `index.html` and assert that it starts loading the files of the release
+///
+/// The CDN rewrites requests to `index.html` in a release (e.g. `/dist/2024-09-11/index.html`) to
+/// point to the `list-files.html` at the root of the bucket, which in turn uses Javascript to fetch
+/// a list of all files in the release. The test asserts that the CDN is correctly rewriting the
+/// path and returning the script.
+async fn request_index_and_expect_loading_files(
+    name: &'static str,
+    base_url: &str,
+    release: &str,
+) -> TestResult {
+    let test_result = TestResult::builder().name(name).success(false);
+
+    let response = match reqwest::get(format!("{}/dist/{}/index.html", base_url, release)).await {
+        Ok(response) => response,
+        Err(error) => {
+            return test_result.message(Some(error.to_string())).build();
+        }
+    };
+
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            return test_result.message(Some(error.to_string())).build();
+        }
+    };
+
+    if !body.contains("Loading directory contents...") {
+        return test_result
+            .message(Some("Expected body to load directory contents".into()))
+            .build();
+    }
+
+    TestResult::builder().name(name).success(true).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let list_files = ListFiles::new(Environment::Staging);
+
+        assert_eq!("list-files.html", list_files.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<ListFiles>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<ListFiles>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<ListFiles>();
+    }
+}

--- a/src/releases/mod.rs
+++ b/src/releases/mod.rs
@@ -5,9 +5,11 @@ use std::fmt::{Display, Formatter};
 use async_trait::async_trait;
 
 use crate::environment::Environment;
+use crate::releases::list_files::ListFiles;
 use crate::releases::rustup_sh::RustupSh;
 use crate::test::{TestGroup, TestSuite, TestSuiteResult};
 
+mod list_files;
 mod rustup_sh;
 
 /// Smoke tests for Rust releases
@@ -36,7 +38,10 @@ impl Display for Releases {
 #[async_trait]
 impl TestSuite for Releases {
     async fn run(&self) -> TestSuiteResult {
-        let groups: Vec<Box<dyn TestGroup>> = vec![Box::new(RustupSh::new(self.env))];
+        let groups: Vec<Box<dyn TestGroup>> = vec![
+            Box::new(ListFiles::new(self.env)),
+            Box::new(RustupSh::new(self.env)),
+        ];
 
         let mut results = Vec::with_capacity(groups.len());
         for group in &groups {


### PR DESCRIPTION
A new smoke test has been added that requires the `index.html` in a release folder and makes sure that the request is rewritten to list the files in the release.